### PR TITLE
Improve documentation and formatting of scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ numpy
 plotly
 scipy
 statsmodels
-argparse

--- a/scripts/annotate.py
+++ b/scripts/annotate.py
@@ -1,20 +1,28 @@
-# annotate.py - Python version of annotation.R
+"""Annotate EWAS results with genomic information.
+
+This script mimics the functionality of the original ``annotation.R`` script. It
+reads an EWAS results file, merges the results with CpG annotations and writes a
+new annotated result file.
+"""
 
 import argparse
-import pandas as pd
 import os
+
+import pandas as pd
 
 # Parse arguments
 parser = argparse.ArgumentParser(description="Add annotation data to EWAS results")
 parser.add_argument("--input-file", "-i", required=True, help="EWAS result file (CSV or TSV)")
 parser.add_argument("--out-dir", required=True, help="Directory to save annotated results")
-parser.add_argument("--stratified", choices=["yes", "no"], default="no", help="Was the analysis stratified")
+parser.add_argument(
+    "--stratified", choices=["yes", "no"], default="no", help="Was the analysis stratified"
+)
 parser.add_argument("--assoc", required=True, help="Association variable name")
 parser.add_argument("--out-type", default=".csv", help="Output file extension")
 args = parser.parse_args()
 
 # Load EWAS results
-df = pd.read_csv(args.input_file, sep=None, engine='python')
+df = pd.read_csv(args.input_file, sep=None, engine="python")
 
 # Load annotation files (assumed to be in annotation_files directory)
 anno_cpg = pd.read_csv("annotation_files/EPIC_hg38.tsv.gz", sep="\t")

--- a/scripts/ewas.py
+++ b/scripts/ewas.py
@@ -1,11 +1,16 @@
-# ewas.py - Python version of ewas.R
+"""Run a basic epigenome-wide association study (EWAS).
+
+This script mirrors the functionality of ``ewas.R`` using ``statsmodels`` to
+perform ordinary least squares regression for each CpG.
+"""
 
 import argparse
-import pandas as pd
-import numpy as np
-from statsmodels.api import OLS, add_constant
-from concurrent.futures import ProcessPoolExecutor
 import os
+from concurrent.futures import ProcessPoolExecutor
+
+import numpy as np
+import pandas as pd
+from statsmodels.api import OLS, add_constant
 
 # Parse arguments
 parser = argparse.ArgumentParser(description="Run EWAS analysis")
@@ -29,8 +34,11 @@ common_samples = pheno["sample_id"].isin(mvals.columns)
 pheno = pheno[common_samples].set_index("sample_id")
 mvals = mvals[pheno.index]
 
+
 # Define analysis function
 def analyze_cpg(cpg_id):
+    """Return association statistics for a single CpG."""
+
     y = mvals.loc[cpg_id]
     X = add_constant(pheno[[args.assoc]].astype(float))
     try:
@@ -38,10 +46,11 @@ def analyze_cpg(cpg_id):
         return {
             "CpG": cpg_id,
             "beta": model.params[args.assoc],
-            "pvalue": model.pvalues[args.assoc]
+            "pvalue": model.pvalues[args.assoc],
         }
     except Exception:
         return {"CpG": cpg_id, "beta": np.nan, "pvalue": np.nan}
+
 
 # Run analysis in chunks
 results = []

--- a/scripts/make_bed.py
+++ b/scripts/make_bed.py
@@ -1,40 +1,45 @@
-# make_bed.py - Python version of make_bed.R
+"""Generate a BED-style file from annotated EWAS results."""
 
 import argparse
-import pandas as pd
 import os
+
+import pandas as pd
 
 # Parse arguments
 parser = argparse.ArgumentParser(description="Create a BED-style file from EWAS results")
 parser.add_argument("--results", required=True, help="Path to annotated EWAS results")
 parser.add_argument("--out-dir", default="results/bed", help="Output directory")
 parser.add_argument("--assoc", required=True, help="Name of the association variable")
-parser.add_argument("--p-threshold", type=float, default=1e-5, help="P-value threshold for filtering CpGs")
+parser.add_argument(
+    "--p-threshold", type=float, default=1e-5, help="P-value threshold for filtering CpGs"
+)
 args = parser.parse_args()
 
 # Load data
-df = pd.read_csv(args.results, sep=None, engine='python')
+df = pd.read_csv(args.results, sep=None, engine="python")
 
 # Filter by p-value
-df_filtered = df[df['pvalue'] < args.p_threshold].copy()
+df_filtered = df[df["pvalue"] < args.p_threshold].copy()
 
 # Ensure required columns exist
-required_cols = ['CHR', 'MAPINFO', 'CpG', 'pvalue']
+required_cols = ["CHR", "MAPINFO", "CpG", "pvalue"]
 missing = [col for col in required_cols if col not in df_filtered.columns]
 if missing:
     raise ValueError(f"Missing required columns in EWAS results: {missing}")
 
 # BED format: chrom, start, end, name, score (we use pvalue as score)
-df_bed = pd.DataFrame({
-    'chrom': df_filtered['CHR'].astype(str),
-    'start': df_filtered['MAPINFO'] - 1,
-    'end': df_filtered['MAPINFO'],
-    'name': df_filtered['CpG'],
-    'score': df_filtered['pvalue']
-})
+df_bed = pd.DataFrame(
+    {
+        "chrom": df_filtered["CHR"].astype(str),
+        "start": df_filtered["MAPINFO"] - 1,
+        "end": df_filtered["MAPINFO"],
+        "name": df_filtered["CpG"],
+        "score": df_filtered["pvalue"],
+    }
+)
 
 # Save to BED-like file
 os.makedirs(args.out_dir, exist_ok=True)
 out_path = os.path.join(args.out_dir, f"{args.assoc}_ewas_results.bed")
-df_bed.to_csv(out_path, sep='\t', index=False, header=False)
+df_bed.to_csv(out_path, sep="\t", index=False, header=False)
 print(f"Saved BED file to {out_path}")

--- a/scripts/plots.py
+++ b/scripts/plots.py
@@ -1,11 +1,12 @@
-# plot_results.py - Python version of plots.R
+"""Create Manhattan and QQ plots from EWAS results."""
 
 import argparse
-import pandas as pd
+import os
+
 import numpy as np
+import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-import os
 import scipy.stats as stats
 
 # Parse arguments
@@ -16,34 +17,48 @@ parser.add_argument("--assoc", required=True, help="Association variable")
 args = parser.parse_args()
 
 # Load annotated EWAS results
-df = pd.read_csv(args.input_file, sep=None, engine='python')
+df = pd.read_csv(args.input_file, sep=None, engine="python")
 
 # Calculate -log10(p-value)
-df['-log10(pvalue)'] = -np.log10(df['pvalue'])
+df["-log10(pvalue)"] = -np.log10(df["pvalue"])
 
 # Manhattan plot
 fig_manhattan = px.scatter(
     df,
-    x='MAPINFO' if 'MAPINFO' in df.columns else 'position',
-    y='-log10(pvalue)',
-    color='CHR' if 'CHR' in df.columns else None,
-    hover_data=['CpG', 'gene'] if 'gene' in df.columns else ['CpG'],
-    title=f"Manhattan Plot - {args.assoc}"
+    x="MAPINFO" if "MAPINFO" in df.columns else "position",
+    y="-log10(pvalue)",
+    color="CHR" if "CHR" in df.columns else None,
+    hover_data=["CpG", "gene"] if "gene" in df.columns else ["CpG"],
+    title=f"Manhattan Plot - {args.assoc}",
 )
 
 # QQ plot
-df_sorted = df[['pvalue']].dropna().sort_values('pvalue')
-df_sorted['expected'] = -np.log10(stats.uniform.ppf((np.arange(1, len(df_sorted)+1)) / (len(df_sorted)+1)))
-df_sorted['observed'] = -np.log10(df_sorted['pvalue'].values)
+df_sorted = df[["pvalue"]].dropna().sort_values("pvalue")
+df_sorted["expected"] = -np.log10(
+    stats.uniform.ppf((np.arange(1, len(df_sorted) + 1)) / (len(df_sorted) + 1))
+)
+df_sorted["observed"] = -np.log10(df_sorted["pvalue"].values)
 
-lambda_gc = np.median(stats.chi2.isf(df_sorted['pvalue'], 1)) / 0.456
+lambda_gc = np.median(stats.chi2.isf(df_sorted["pvalue"], 1)) / 0.456
 
 fig_qq = go.Figure()
-fig_qq.add_trace(go.Scatter(x=df_sorted['expected'], y=df_sorted['observed'], mode='markers', name='Observed'))
-fig_qq.add_trace(go.Scatter(x=df_sorted['expected'], y=df_sorted['expected'], mode='lines', line=dict(dash='dash'), name='Expected'))
-fig_qq.update_layout(title=f"QQ Plot - {args.assoc} (lambda={lambda_gc:.2f})",
-                     xaxis_title="Expected -log10(p)",
-                     yaxis_title="Observed -log10(p)")
+fig_qq.add_trace(
+    go.Scatter(x=df_sorted["expected"], y=df_sorted["observed"], mode="markers", name="Observed")
+)
+fig_qq.add_trace(
+    go.Scatter(
+        x=df_sorted["expected"],
+        y=df_sorted["expected"],
+        mode="lines",
+        line=dict(dash="dash"),
+        name="Expected",
+    )
+)
+fig_qq.update_layout(
+    title=f"QQ Plot - {args.assoc} (lambda={lambda_gc:.2f})",
+    xaxis_title="Expected -log10(p)",
+    yaxis_title="Observed -log10(p)",
+)
 
 # Save plots
 os.makedirs(args.out_dir, exist_ok=True)

--- a/scripts/stratify.py
+++ b/scripts/stratify.py
@@ -1,14 +1,15 @@
-# stratify.py - Python version of stratify.R
+"""Split phenotype and methylation data into stratified groups."""
 
 import argparse
-import pandas as pd
 import os
+
+import pandas as pd
 
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description="Stratify phenotype and methylation data")
 parser.add_argument("--pheno", required=True, help="Path to phenotype data")
 parser.add_argument("--methyl", required=True, help="Path to methylation matrix")
-parser.add_argument("--stratify", nargs='+', required=True, help="List of variables to stratify by")
+parser.add_argument("--stratify", nargs="+", required=True, help="List of variables to stratify by")
 parser.add_argument("--out-dir", default="results/stratified")
 args = parser.parse_args()
 
@@ -32,7 +33,9 @@ os.makedirs(args.out_dir, exist_ok=True)
 
 # Split data and write to files
 for group_vals, sub_pheno in groups:
-    group_name = "_".join(str(v) for v in group_vals) if isinstance(group_vals, tuple) else str(group_vals)
+    group_name = (
+        "_".join(str(v) for v in group_vals) if isinstance(group_vals, tuple) else str(group_vals)
+    )
     sub_mvals = mvals.loc[:, sub_pheno.index]
 
     pheno_path = os.path.join(args.out_dir, f"{group_name}_pheno.csv")


### PR DESCRIPTION
## Summary
- remove unnecessary argparse from requirements
- document each script with module-level docstrings
- document the analyze_cpg helper function
- reorder imports and run `black`

## Testing
- `black --check --line-length 100 scripts/*.py`
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684b8f5896808321a5c9db2fedd515a3