### PR TITLE
Improve pipeline scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,19 @@ Assuming your phenotype table (`pheno.csv`) and methylation matrix (`mvals.csv.g
 ```bash
 python scripts/ewas.py --pheno data/pheno.csv --methyl data/mvals.csv.gz --assoc BMI --out-dir output/ewas
 ```
+Use `--sample-id-col` if your phenotype table uses a different column name for sample IDs. The script will automatically transpose the methylation matrix if samples are found on rows.
 
 ### Stratify the data
 ```bash
 python scripts/stratify.py --pheno data/pheno.csv --methyl data/mvals.csv.gz --stratify sex re --out-dir output/stratified
 ```
+If your phenotype table uses another sample column, specify it with `--sample-id-col`.
 
 ### Annotate EWAS results
 ```bash
 python scripts/annotate.py --input-file output/ewas/ewas_results.csv --out-dir output/annotated --assoc BMI --stratified no
 ```
+Use `--anno-file` to provide a different CpG annotation file if needed.
 Annotation files such as `EPIC_hg38.tsv.gz` and `EPIC_snp_key.tsv.gz` are expected inside an `annotation_files` directory.
 
 ### Create a BED file

--- a/scripts/annotate.py
+++ b/scripts/annotate.py
@@ -1,37 +1,54 @@
-"""Annotate EWAS results with genomic information.
-
-This script mimics the functionality of the original ``annotation.R`` script. It
-reads an EWAS results file, merges the results with CpG annotations and writes a
-new annotated result file.
-"""
+"""Annotate EWAS results with genomic information."""
 
 import argparse
 import os
 
 import pandas as pd
 
-# Parse arguments
-parser = argparse.ArgumentParser(description="Add annotation data to EWAS results")
-parser.add_argument("--input-file", "-i", required=True, help="EWAS result file (CSV or TSV)")
-parser.add_argument("--out-dir", required=True, help="Directory to save annotated results")
-parser.add_argument(
-    "--stratified", choices=["yes", "no"], default="no", help="Was the analysis stratified"
-)
-parser.add_argument("--assoc", required=True, help="Association variable name")
-parser.add_argument("--out-type", default=".csv", help="Output file extension")
-args = parser.parse_args()
 
-# Load EWAS results
-df = pd.read_csv(args.input_file, sep=None, engine="python")
+def main() -> None:
+    """Entry point for command line usage."""
 
-# Load annotation file (assumed to be in annotation_files directory)
-anno_cpg = pd.read_csv("annotation_files/EPIC_hg38.tsv.gz", sep="\t")
+    parser = argparse.ArgumentParser(
+        description="Add annotation data to EWAS results"
+    )
+    parser.add_argument(
+        "--input-file",
+        "-i",
+        required=True,
+        help="EWAS result file (CSV or TSV)",
+    )
+    parser.add_argument(
+        "--out-dir", required=True, help="Directory to save annotated results"
+    )
+    parser.add_argument(
+        "--stratified",
+        choices=["yes", "no"],
+        default="no",
+        help="Was the analysis stratified",
+    )
+    parser.add_argument("--assoc", required=True, help="Association variable name")
+    parser.add_argument("--out-type", default=".csv", help="Output file extension")
+    parser.add_argument(
+        "--anno-file",
+        default="annotation_files/EPIC_hg38.tsv.gz",
+        help="Path to annotation file",
+    )
+    args = parser.parse_args()
 
-# Merge EWAS results with CpG annotations
-annotated = df.merge(anno_cpg, on="CpG", how="left")
+    df = pd.read_csv(args.input_file, sep=None, engine="python")
 
-# Save annotated output
-os.makedirs(args.out_dir, exist_ok=True)
-out_path = os.path.join(args.out_dir, f"{args.assoc}_ewas_annotated_results{args.out_type}")
-annotated.to_csv(out_path, index=False)
-print(f"Annotated results saved to {out_path}")
+    anno_cpg = pd.read_csv(args.anno_file, sep="\t")
+
+    annotated = df.merge(anno_cpg, on="CpG", how="left")
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    out_path = os.path.join(
+        args.out_dir, f"{args.assoc}_ewas_annotated_results{args.out_type}"
+    )
+    annotated.to_csv(out_path, index=False)
+    print(f"Annotated results saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ewas.py
+++ b/scripts/ewas.py
@@ -3,7 +3,6 @@
 This script mirrors the functionality of ``ewas.R`` using ``statsmodels`` to
 perform ordinary least squares regression for each CpG.
 """
-
 import argparse
 import os
 from concurrent.futures import ProcessPoolExecutor
@@ -12,69 +11,87 @@ import numpy as np
 import pandas as pd
 from statsmodels.api import OLS, add_constant
 
-# Parse arguments
-parser = argparse.ArgumentParser(description="Run EWAS analysis")
-parser.add_argument("--pheno", required=True, help="Phenotype file")
-parser.add_argument("--methyl", required=True, help="Methylation matrix")
-parser.add_argument("--assoc", required=True, help="Variable to associate")
-parser.add_argument("--chunk-size", type=int, default=1000)
-parser.add_argument("--out-dir", default="results/")
-parser.add_argument("--out-type", default=".csv")
-parser.add_argument("--workers", type=int, default=4)
-parser.add_argument(
-    "--sample-id-col",
-    default="sampleID",
-    help="Column name for sample identifiers in the phenotype file",
-)
-args = parser.parse_args()
 
-# Load data
-pheno = pd.read_csv(args.pheno)
-mvals = pd.read_csv(args.methyl, index_col=0)
+def main() -> None:
+    """Entry point for command line execution."""
 
-assert args.assoc in pheno.columns, f"Association variable {args.assoc} not found"
-
-# Validate sample ID column
-if args.sample_id_col not in pheno.columns:
-    raise ValueError(
-        f"Phenotype file must contain a '{args.sample_id_col}' column"
+    parser = argparse.ArgumentParser(description="Run EWAS analysis")
+    parser.add_argument("--pheno", required=True, help="Phenotype file")
+    parser.add_argument("--methyl", required=True, help="Methylation matrix")
+    parser.add_argument("--assoc", required=True, help="Variable to associate")
+    parser.add_argument("--chunk-size", type=int, default=1000)
+    parser.add_argument("--out-dir", default="results/")
+    parser.add_argument("--out-type", default=".csv")
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument(
+        "--sample-id-col",
+        default="sampleID",
+        help="Column name for sample identifiers in the phenotype file",
     )
+    args = parser.parse_args()
 
-# Merge data
-common_samples = pheno[args.sample_id_col].isin(mvals.columns)
-pheno = pheno[common_samples].set_index(args.sample_id_col)
-mvals = mvals[pheno.index]
+    # Load data
+    pheno = pd.read_csv(args.pheno)
+    mvals = pd.read_csv(args.methyl, index_col=0)
+
+    if args.assoc not in pheno.columns:
+        raise ValueError(f"Association variable {args.assoc} not found")
+
+    # Validate sample ID column
+    if args.sample_id_col not in pheno.columns:
+        raise ValueError(
+            f"Phenotype file must contain a '{args.sample_id_col}' column"
+        )
+
+    sample_ids = pheno[args.sample_id_col].astype(str)
+    # Determine orientation of methylation matrix
+    cols_match = sample_ids.isin(mvals.columns.astype(str)).all()
+    rows_match = sample_ids.isin(mvals.index.astype(str)).all()
+    if not cols_match and rows_match:
+        # Samples appear on rows -> transpose
+        mvals = mvals.T
+        print("Transposed methylation matrix to match sample orientation")
+    elif not cols_match and not rows_match:
+        raise ValueError("Sample IDs do not match methylation matrix dimensions")
+
+    # Merge data
+    pheno = pheno.set_index(args.sample_id_col)
+    mvals = mvals.loc[:, pheno.index]
+
+    design_matrix = add_constant(pheno[[args.assoc]].astype(float))
+
+    # Define analysis function
+    def analyze_cpg(cpg_id):
+        """Return association statistics for a single CpG."""
+
+        y = mvals.loc[cpg_id]
+        try:
+            model = OLS(y, design_matrix).fit()
+            return {
+                "CpG": cpg_id,
+                "beta": model.params[args.assoc],
+                "pvalue": model.pvalues[args.assoc],
+            }
+        except Exception:
+            return {"CpG": cpg_id, "beta": np.nan, "pvalue": np.nan}
+
+    # Run analysis in chunks
+    results = []
+    cpg_list = mvals.index.tolist()
+    with ProcessPoolExecutor(max_workers=args.workers) as executor:
+        for i in range(0, len(cpg_list), args.chunk_size):
+            batch = cpg_list[i : i + args.chunk_size]
+            for res in executor.map(analyze_cpg, batch):
+                results.append(res)
+
+    # Save output
+    out_df = pd.DataFrame(results)
+    os.makedirs(args.out_dir, exist_ok=True)
+    out_path = os.path.join(args.out_dir, f"ewas_results{args.out_type}")
+    out_df.to_csv(out_path, index=False)
+    print(f"Results saved to {out_path}")
 
 
-# Define analysis function
-def analyze_cpg(cpg_id):
-    """Return association statistics for a single CpG."""
+if __name__ == "__main__":
+    main()
 
-    y = mvals.loc[cpg_id]
-    X = add_constant(pheno[[args.assoc]].astype(float))
-    try:
-        model = OLS(y, X).fit()
-        return {
-            "CpG": cpg_id,
-            "beta": model.params[args.assoc],
-            "pvalue": model.pvalues[args.assoc],
-        }
-    except Exception:
-        return {"CpG": cpg_id, "beta": np.nan, "pvalue": np.nan}
-
-
-# Run analysis in chunks
-results = []
-cpg_list = mvals.index.tolist()
-with ProcessPoolExecutor(max_workers=args.workers) as executor:
-    for i in range(0, len(cpg_list), args.chunk_size):
-        batch = cpg_list[i:i + args.chunk_size]
-        for res in executor.map(analyze_cpg, batch):
-            results.append(res)
-
-# Save output
-out_df = pd.DataFrame(results)
-os.makedirs(args.out_dir, exist_ok=True)
-out_path = os.path.join(args.out_dir, f"ewas_results{args.out_type}")
-out_df.to_csv(out_path, index=False)
-print(f"Results saved to {out_path}")

--- a/scripts/make_bed.py
+++ b/scripts/make_bed.py
@@ -5,41 +5,43 @@ import os
 
 import pandas as pd
 
-# Parse arguments
-parser = argparse.ArgumentParser(description="Create a BED-style file from EWAS results")
-parser.add_argument("--results", required=True, help="Path to annotated EWAS results")
-parser.add_argument("--out-dir", default="results/bed", help="Output directory")
-parser.add_argument("--assoc", required=True, help="Name of the association variable")
-parser.add_argument(
-    "--p-threshold", type=float, default=1e-5, help="P-value threshold for filtering CpGs"
-)
-args = parser.parse_args()
 
-# Load data
-df = pd.read_csv(args.results, sep=None, engine="python")
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create a BED-style file from EWAS results"
+    )
+    parser.add_argument("--results", required=True, help="Path to annotated EWAS results")
+    parser.add_argument("--out-dir", default="results/bed", help="Output directory")
+    parser.add_argument("--assoc", required=True, help="Name of the association variable")
+    parser.add_argument(
+        "--p-threshold", type=float, default=1e-5, help="P-value threshold for filtering CpGs"
+    )
+    args = parser.parse_args()
 
-# Filter by p-value
-df_filtered = df[df["pvalue"] < args.p_threshold].copy()
+    df = pd.read_csv(args.results, sep=None, engine="python")
 
-# Ensure required columns exist
-required_cols = ["CHR", "MAPINFO", "CpG", "pvalue"]
-missing = [col for col in required_cols if col not in df_filtered.columns]
-if missing:
-    raise ValueError(f"Missing required columns in EWAS results: {missing}")
+    df_filtered = df[df["pvalue"] < args.p_threshold].copy()
 
-# BED format: chrom, start, end, name, score (we use pvalue as score)
-df_bed = pd.DataFrame(
-    {
-        "chrom": df_filtered["CHR"].astype(str),
-        "start": df_filtered["MAPINFO"] - 1,
-        "end": df_filtered["MAPINFO"],
-        "name": df_filtered["CpG"],
-        "score": df_filtered["pvalue"],
-    }
-)
+    required_cols = ["CHR", "MAPINFO", "CpG", "pvalue"]
+    missing = [col for col in required_cols if col not in df_filtered.columns]
+    if missing:
+        raise ValueError(f"Missing required columns in EWAS results: {missing}")
 
-# Save to BED-like file
-os.makedirs(args.out_dir, exist_ok=True)
-out_path = os.path.join(args.out_dir, f"{args.assoc}_ewas_results.bed")
-df_bed.to_csv(out_path, sep="\t", index=False, header=False)
-print(f"Saved BED file to {out_path}")
+    df_bed = pd.DataFrame(
+        {
+            "chrom": df_filtered["CHR"].astype(str),
+            "start": df_filtered["MAPINFO"] - 1,
+            "end": df_filtered["MAPINFO"],
+            "name": df_filtered["CpG"],
+            "score": df_filtered["pvalue"],
+        }
+    )
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    out_path = os.path.join(args.out_dir, f"{args.assoc}_ewas_results.bed")
+    df_bed.to_csv(out_path, sep="\t", index=False, header=False)
+    print(f"Saved BED file to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plots.py
+++ b/scripts/plots.py
@@ -9,60 +9,65 @@ import plotly.express as px
 import plotly.graph_objects as go
 import scipy.stats as stats
 
-# Parse arguments
-parser = argparse.ArgumentParser(description="Plot Manhattan and QQ plots from EWAS results")
-parser.add_argument("--input-file", "-i", required=True, help="Annotated EWAS results file")
-parser.add_argument("--out-dir", required=True, help="Directory to save plots")
-parser.add_argument("--assoc", required=True, help="Association variable")
-args = parser.parse_args()
 
-# Load annotated EWAS results
-df = pd.read_csv(args.input_file, sep=None, engine="python")
-
-# Calculate -log10(p-value)
-df["-log10(pvalue)"] = -np.log10(df["pvalue"])
-
-# Manhattan plot
-fig_manhattan = px.scatter(
-    df,
-    x="MAPINFO" if "MAPINFO" in df.columns else "position",
-    y="-log10(pvalue)",
-    color="CHR" if "CHR" in df.columns else None,
-    hover_data=["CpG", "gene"] if "gene" in df.columns else ["CpG"],
-    title=f"Manhattan Plot - {args.assoc}",
-)
-
-# QQ plot
-df_sorted = df[["pvalue"]].dropna().sort_values("pvalue")
-df_sorted["expected"] = -np.log10(
-    stats.uniform.ppf((np.arange(1, len(df_sorted) + 1)) / (len(df_sorted) + 1))
-)
-df_sorted["observed"] = -np.log10(df_sorted["pvalue"].values)
-
-lambda_gc = np.median(stats.chi2.isf(df_sorted["pvalue"], 1)) / 0.456
-
-fig_qq = go.Figure()
-fig_qq.add_trace(
-    go.Scatter(x=df_sorted["expected"], y=df_sorted["observed"], mode="markers", name="Observed")
-)
-fig_qq.add_trace(
-    go.Scatter(
-        x=df_sorted["expected"],
-        y=df_sorted["expected"],
-        mode="lines",
-        line=dict(dash="dash"),
-        name="Expected",
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Plot Manhattan and QQ plots from EWAS results"
     )
-)
-fig_qq.update_layout(
-    title=f"QQ Plot - {args.assoc} (lambda={lambda_gc:.2f})",
-    xaxis_title="Expected -log10(p)",
-    yaxis_title="Observed -log10(p)",
-)
+    parser.add_argument("--input-file", "-i", required=True, help="Annotated EWAS results file")
+    parser.add_argument("--out-dir", required=True, help="Directory to save plots")
+    parser.add_argument("--assoc", required=True, help="Association variable")
+    parser.add_argument(
+        "--out-type", default="html", help="Plot file extension (html or png)"
+    )
+    args = parser.parse_args()
 
-# Save plots
-os.makedirs(args.out_dir, exist_ok=True)
-fig_manhattan.write_html(os.path.join(args.out_dir, f"manhattan_{args.assoc}.html"))
-fig_qq.write_html(os.path.join(args.out_dir, f"qq_{args.assoc}.html"))
+    df = pd.read_csv(args.input_file, sep=None, engine="python")
 
-print(f"Saved Manhattan and QQ plots to {args.out_dir}")
+    df["-log10(pvalue)"] = -np.log10(df["pvalue"])
+
+    fig_manhattan = px.scatter(
+        df,
+        x="MAPINFO" if "MAPINFO" in df.columns else "position",
+        y="-log10(pvalue)",
+        color="CHR" if "CHR" in df.columns else None,
+        hover_data=["CpG", "gene"] if "gene" in df.columns else ["CpG"],
+        title=f"Manhattan Plot - {args.assoc}",
+    )
+
+    df_sorted = df[["pvalue"]].dropna().sort_values("pvalue")
+    df_sorted["expected"] = -np.log10(
+        stats.uniform.ppf((np.arange(1, len(df_sorted) + 1)) / (len(df_sorted) + 1))
+    )
+    df_sorted["observed"] = -np.log10(df_sorted["pvalue"].values)
+
+    lambda_gc = np.median(stats.chi2.isf(df_sorted["pvalue"], 1)) / 0.456
+
+    fig_qq = go.Figure()
+    fig_qq.add_trace(
+        go.Scatter(x=df_sorted["expected"], y=df_sorted["observed"], mode="markers", name="Observed")
+    )
+    fig_qq.add_trace(
+        go.Scatter(
+            x=df_sorted["expected"],
+            y=df_sorted["expected"],
+            mode="lines",
+            line=dict(dash="dash"),
+            name="Expected",
+        )
+    )
+    fig_qq.update_layout(
+        title=f"QQ Plot - {args.assoc} (lambda={lambda_gc:.2f})",
+        xaxis_title="Expected -log10(p)",
+        yaxis_title="Observed -log10(p)",
+    )
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    fig_manhattan.write_html(os.path.join(args.out_dir, f"manhattan_{args.assoc}.{args.out_type}"))
+    fig_qq.write_html(os.path.join(args.out_dir, f"qq_{args.assoc}.{args.out_type}"))
+
+    print(f"Saved Manhattan and QQ plots to {args.out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stratify.py
+++ b/scripts/stratify.py
@@ -5,42 +5,46 @@ import os
 
 import pandas as pd
 
-# Parse command-line arguments
-parser = argparse.ArgumentParser(description="Stratify phenotype and methylation data")
-parser.add_argument("--pheno", required=True, help="Path to phenotype data")
-parser.add_argument("--methyl", required=True, help="Path to methylation matrix")
-parser.add_argument("--stratify", nargs="+", required=True, help="List of variables to stratify by")
-parser.add_argument("--out-dir", default="results/stratified")
-args = parser.parse_args()
 
-# Load data
-pheno = pd.read_csv(args.pheno)
-mvals = pd.read_csv(args.methyl, index_col=0)
-
-# Ensure sample_id column exists
-if "sample_id" not in pheno.columns:
-    raise ValueError("Phenotype file must contain a 'sample_id' column")
-
-# Make sure sample_id is index for matching
-pheno = pheno.set_index("sample_id")
-mvals = mvals.loc[:, pheno.index]
-
-# Get all stratified combinations
-groups = pheno.groupby(args.stratify)
-
-# Create output directory
-os.makedirs(args.out_dir, exist_ok=True)
-
-# Split data and write to files
-for group_vals, sub_pheno in groups:
-    group_name = (
-        "_".join(str(v) for v in group_vals) if isinstance(group_vals, tuple) else str(group_vals)
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Stratify phenotype and methylation data")
+    parser.add_argument("--pheno", required=True, help="Path to phenotype data")
+    parser.add_argument("--methyl", required=True, help="Path to methylation matrix")
+    parser.add_argument("--stratify", nargs="+", required=True, help="List of variables to stratify by")
+    parser.add_argument("--out-dir", default="results/stratified")
+    parser.add_argument(
+        "--sample-id-col",
+        default="sampleID",
+        help="Column name for sample identifiers in the phenotype file",
     )
-    sub_mvals = mvals.loc[:, sub_pheno.index]
+    args = parser.parse_args()
 
-    pheno_path = os.path.join(args.out_dir, f"{group_name}_pheno.csv")
-    mvals_path = os.path.join(args.out_dir, f"{group_name}_mvals.csv")
+    pheno = pd.read_csv(args.pheno)
+    mvals = pd.read_csv(args.methyl, index_col=0)
 
-    sub_pheno.to_csv(pheno_path)
-    sub_mvals.to_csv(mvals_path)
-    print(f"Saved: {group_name}")
+    if args.sample_id_col not in pheno.columns:
+        raise ValueError(f"Phenotype file must contain a '{args.sample_id_col}' column")
+
+    pheno = pheno.set_index(args.sample_id_col)
+    mvals = mvals.loc[:, pheno.index]
+
+    groups = pheno.groupby(args.stratify)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    for group_vals, sub_pheno in groups:
+        group_name = (
+            "_".join(str(v) for v in group_vals) if isinstance(group_vals, tuple) else str(group_vals)
+        )
+        sub_mvals = mvals.loc[:, sub_pheno.index]
+
+        pheno_path = os.path.join(args.out_dir, f"{group_name}_pheno.csv")
+        mvals_path = os.path.join(args.out_dir, f"{group_name}_mvals.csv")
+
+        sub_pheno.to_csv(pheno_path)
+        sub_mvals.to_csv(mvals_path)
+        print(f"Saved: {group_name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add main wrappers for easier use as modules
- compute regression design matrix once
- handle transposed methylation matrices
- parameterize CpG annotation file location
- allow custom sample ID column in stratify
- include minor README notes

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684c37b659f08321a262eacc2b1a66f1