### PR TITLE
Update README for stratify orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ python scripts/stratify.py --pheno data/pheno.csv --methyl data/mvals.csv.gz --s
 ```
 If your phenotype table uses another sample column, specify it with `--sample-id-col`.
 
+`stratify.py` expects samples as columns in the methylation matrix. If your
+matrix has samples on the rows, transpose it first. The following example uses
+pandas and removes the need for the external `csvtool` utility:
+
+```bash
+gunzip -c data/mvals.csv.gz | python - <<'EOF'
+import pandas as pd, sys
+df = pd.read_csv(sys.stdin, index_col=0)
+df.T.to_csv("data/mvals_t.csv")
+EOF
+```
+
 ### Annotate EWAS results
 ```bash
 python scripts/annotate.py --input-file output/ewas/ewas_results.csv --out-dir output/annotated --assoc BMI --stratified no


### PR DESCRIPTION
## Summary
- clarify that `stratify.py` expects samples as columns
- add pandas snippet for transposing data
- note that this eliminates the csvtool dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6800557c83218abfc3da64f03779